### PR TITLE
Add support for integer, decimal and another type columns to `simple_search_attributes ` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ It offers simple but useful features:
 - [Search on the default attributes](#search-on-the-default-attributes)
 - [Override default search attributes to specific attributes ](#override-default-search-attributes-to-specific-attributes) (Credit goes to [@abdullahtariq1171](https://github.com/abdullahtariq1171))
 - [Search using patterns](#search-using-patterns)
-- [Ruby Block support to extend the search query](#ruby-block-support-to-extend-the-search-query)
-- [Simple search returns an `ActiveRecord::Relation`](#simple-search-returns-an-activerecordrelation)
+- [Ruby block support to extend the search query](#ruby-block-support-to-extend-the-search-query)
+- [Simple search returns an `ActiveRecord::Relation` object](#simple-search-returns-an-activerecordrelation-object)
 
 Mostly on the admin side, we do have a standard text field to search the data on the table.
-Sometimes we want to search for the title, content and ratings on the post model or email,
-username and description on the user model. For those searches, we use MySQL's or PostgreSQL's
-`LIKE` operator to get the results. While doing the same thing again and again on the different
-models, you add lots of duplication in your code.
+Sometimes we want to search through the attributes like title, content and ratings on the
+post model or email, username and description on the user model. For those searches, we use
+MySQL's or PostgreSQL's `LIKE` operator to get the results. While doing the same thing again
+and again on the different models, you add lots of duplication in your code.
 
 #### Do not repeat yourself, use RubySimpleSearch.
 
@@ -28,7 +28,7 @@ Add this line to your application's Gemfile:
 
 And then execute:
 
-    $ bundle
+    $ bundle install
 
 Or install it yourself as:
 
@@ -50,19 +50,16 @@ end
 class User < ActiveActiveRecord::Base
   include RubySimpleSearch
 
-  simple_search_attributes :email, :username, :address
+  simple_search_attributes :email, :username, :address, :age
 end
 ```
-
-Please do not pass **integer/decimal** data type attributes to the `simple_search_attributes `
-method, instead; you can handle these types by passing block to the `simple_search` method.
-Block should return an array of search condition and values.
 
 ## Features
 
 ### Search on the default attributes
-If you don't provide any attribute at time of searching it will use `simple_search_attributes` from modal.
-```
+If you don't provide any attribute at the time of searching, it will use `simple_search_attributes` from the model.
+
+```ruby
 class User < ActiveActiveRecord::Base
   include RubySimpleSearch
 
@@ -74,11 +71,11 @@ Post.simple_search('york')
 # It will search in :email, :username and :address only
 ```
 
-
 ### Override default search attributes to specific attributes
 
-If you wan't to perform a specific search on particular attributes, you can pass specific attributes with `attributes` option
-```
+If you want to perform a specific search on particular attributes, you can pass specific attributes with `attributes` option.
+
+```ruby
 class User < ActiveActiveRecord::Base
   include RubySimpleSearch
 
@@ -92,11 +89,18 @@ Post.simple_search('york', attributes: :address)
 # It will search in :address only
 
 User.simple_search('york', pattern: :ending, attributes: [:email, :address])
-# It will search in :name and :address only
+# It will search in :email and :address only with 'ending' pattern
 ```
 
 ### Search using patterns
-You can pass a `LIKE` pattern to the `simple_search` method
+You can pass a `LIKE` pattern to the `simple_search` method. 
+
+Patterns:
+
+- beginning
+- ending
+- containing (Default pattern)
+- plain
 
 ```ruby
 Post.simple_search('york', pattern: :beginning)
@@ -112,16 +116,16 @@ Post.simple_search('york', pattern: :plain)
 # It will search like 'york' and finds any values that have "york" word
 ```
 
-### Ruby Block support to extend the search query
-
+### Ruby block support to extend the search query
 
 ```Ruby
 User.simple_search('35') do |search_term|
   ["AND age = ?", search_term]
 end
 ```
+Block should return an array of search condition and values.
 
-### Simple search returns an `ActiveRecord::Relation`
+### Simple search returns an `ActiveRecord::Relation` object
 
 ```Ruby
 Model.simple_search('string') # => ActiveRecord::Relation object

--- a/lib/ruby_simple_search.rb
+++ b/lib/ruby_simple_search.rb
@@ -86,11 +86,11 @@ module RubySimpleSearch
 
     def build_query_non_string_text_type(attribute)
       condition = if @simple_search_query_conditions.blank?
-                    "#{table_name}.#{attribute} = ?"
+                    "CAST(#{table_name}.#{attribute} AS CHAR(255)) LIKE ?"
                   else
-                    " OR #{table_name}.#{attribute} = ?"
+                    " OR CAST(#{table_name}.#{attribute} AS CHAR(255)) LIKE ?"
                   end
-      [condition, @simple_search_term]
+      [condition, @simple_search_patterned_text]
     end
 
     def extend_query(block)

--- a/test/mysql_test.rb
+++ b/test/mysql_test.rb
@@ -10,22 +10,17 @@ module ActiveRecord
 end
 
 class MysqlTest < Minitest::Test
+  include GemSetupTest
   include ExcpetionsTest
-  include UserTest
+  include SearchTest
   include JoinTest
-
-  @setup = nil
 
   def setup
     super
-    @setup ||= begin
-                 ActiveRecord::Base.establish_connection adapter: 'mysql2', database: 'ruby_simple_search_test', host: 'localhost'
-                 create_tables
-                 create_dummy_data
-               end
-  end
-
-  def teardown
-    drop_database
+    @@setup ||= begin
+                  ActiveRecord::Base.establish_connection adapter: 'mysql2', database: 'ruby_simple_search_test', host: 'localhost'
+                  create_tables
+                  create_dummy_data
+                end
   end
 end

--- a/test/postgresql_test.rb
+++ b/test/postgresql_test.rb
@@ -1,22 +1,17 @@
 require_relative 'test_helper'
 
 class PostgresqlTest < Minitest::Test
+  include GemSetupTest
   include ExcpetionsTest
-  include UserTest
+  include SearchTest
   include JoinTest
-
-  @setup = nil
 
   def setup
     super
-    @setup ||= begin
-                 ActiveRecord::Base.establish_connection adapter: 'postgresql', database: 'ruby_simple_search_test'
-                 create_tables
-                 create_dummy_data
-               end
-  end
-
-  def teardown
-    drop_database
+    @@setup ||= begin
+                  ActiveRecord::Base.establish_connection adapter: 'postgresql', database: 'ruby_simple_search_test'
+                  create_tables
+                  create_dummy_data
+                end
   end
 end

--- a/test/sqlite_test.rb
+++ b/test/sqlite_test.rb
@@ -1,22 +1,17 @@
 require_relative 'test_helper'
 
 class TestSqlite < Minitest::Test
+  include GemSetupTest
   include ExcpetionsTest
-  include UserTest
+  include SearchTest
   include JoinTest
-
-  @setup = nil
 
   def setup
     super
-    @setup ||= begin
-                 ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
-                 create_tables
-                 create_dummy_data
-               end
-  end
-
-  def teardown
-    drop_database
+    @@setup ||= begin
+                  ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
+                  create_tables
+                  create_dummy_data
+                end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,7 +22,6 @@ class User2 < ActiveRecord::Base
   include RubySimpleSearch
 end
 
-# migration
 def create_tables
   ActiveRecord::Migration.verbose = false
 
@@ -68,21 +67,9 @@ def create_dummy_data
   Post.create! name: 'Ruby is simple', user: alice
 end
 
-def drop_database
-  ActiveRecord::Migration.verbose = false
-
-  if ActiveRecord::Migration.table_exists?(:users)
-    ActiveRecord::Migration.drop_table(:users)
-  end
-end
-
-module UserTest
-  # Test initial setup gets set properly
-
+module GemSetupTest
   def test_no_exception_is_raised_if_simple_search_attributes_is_called_in_the_model
-    # This will just make sure that internal variables for RubySimpleSearch
-    # get set properly.
-
+    User.simple_search_attributes :name, :email, :contact, :address
     assert_silent { User.simple_search('USA') }
   end
 
@@ -93,12 +80,15 @@ module UserTest
   end
 
   def test_it_has_default_like_pattern
+    User.simple_search_attributes :name, :email, :contact, :address
     User.simple_search('Alice')
 
     assert_equal '%q%', User.instance_variable_get('@simple_search_pattern')
   end
 
   def test_it_can_have_patterns_like_plain_beginning_ending_and_containing
+    User.simple_search_attributes :name, :email, :contact, :address
+
     User.simple_search('alice', pattern: :plain)
     assert_equal 'q', User.instance_variable_get('@simple_search_pattern')
 
@@ -110,8 +100,12 @@ module UserTest
     User.simple_search('alice', pattern: :containing)
     assert_equal '%q%', User.instance_variable_get('@simple_search_pattern')
   end
+end
 
+module SearchTest
   def test_it_searches_the_users_whose_names_are_alice
+    User.simple_search_attributes :name, :email, :contact, :address, :age
+
     user  = User.find_by_name('alice')
     users = User.simple_search('alice')
 
@@ -119,6 +113,8 @@ module UserTest
   end
 
   def test_it_raises_an_exception_if_pattern_is_wrong
+    User.simple_search_attributes :name, :email, :contact, :address
+
     error = assert_raises(RuntimeError) do
       User.simple_search('alice', pattern: 'wrong')
     end
@@ -127,6 +123,8 @@ module UserTest
   end
 
   def test_it_searches_the_users_whose_names_are_alice_with_beginning_pattern
+    User.simple_search_attributes :name, :email, :contact, :address
+
     user  = User.find_by_name('alice')
     users = User.simple_search('al', pattern: :beginning)
 
@@ -134,18 +132,24 @@ module UserTest
   end
 
   def test_it_returns_empty_users_if_pattern_is_beginning_but_query_has_non_beginning_characters
+    User.simple_search_attributes :name, :email, :contact, :address
+
     users = User.simple_search('ce', pattern: :beginning)
 
     assert_empty users
   end
 
   def test_it_returns_empty_records_if_contact_number_does_not_exist
+    User.simple_search_attributes :name, :email, :contact, :address
+
     users = User.simple_search('343434')
 
     assert_empty users
   end
 
   def test_it_searches_user_records_if_users_belong_to_usa
+    User.simple_search_attributes :name, :email, :contact, :address
+
     users          = User.where(address: 'usa')
     searched_users = User.simple_search('USA')
 
@@ -153,24 +157,27 @@ module UserTest
   end
 
   def test_it_searches_the_records_with_beginning_pattern
-    users = User.where('name like ?', 'bo%')
+    User.simple_search_attributes :name, :email, :contact, :address
 
+    users          = User.where('name like ?', 'bo%')
     searched_users = User.simple_search('bo', pattern: :beginning)
 
     assert_equal searched_users.count, users.count
   end
 
   def test_searches_the_records_with_ending_pattern
-    users = User.where('name like ?', '%ce')
+    User.simple_search_attributes :name, :email, :contact, :address
 
+    users          = User.where('name like ?', '%ce')
     searched_users = User.simple_search('ce', pattern: :ending)
 
     assert_equal searched_users.count, users.count
   end
 
   def test_searches_the_records_with_plain_pattern
-    users = User.where('name like ?', 'bob')
+    User.simple_search_attributes :name, :email, :contact, :address
 
+    users          = User.where('name like ?', 'bob')
     searched_users = User.simple_search('bob', pattern: :plain)
 
     assert_equal searched_users.count, users.count
@@ -188,6 +195,8 @@ module UserTest
   end
 
   def test_returns_an_exception_if_array_condition_is_wrong_in_simple_search_block
+    User.simple_search_attributes :name, :contact, :address
+
     error = assert_raises(RuntimeError) do
       User.simple_search('usa') do
         ['AND age > ?', 50, 60]
@@ -198,6 +207,8 @@ module UserTest
   end
 
   def test_returns_an_exception_if_condition_is_not_an_array_type
+    User.simple_search_attributes :name, :contact, :address
+
     error = assert_raises(RuntimeError) do
       User.simple_search('usa') do
         'Wrong return'
@@ -208,29 +219,57 @@ module UserTest
   end
 
   def test_searches_the_users_with_age_is_26
+    User.simple_search_attributes :name, :contact, :address
+
     searched_users = User.simple_search('26', pattern: :containing, attributes: :age)
+
     assert_equal [26], searched_users.pluck(:age)
   end
 
   def test_it_searches_the_users_with_username_and_it_ends_with_khan_word
+    User.simple_search_attributes :name, :contact, :address
+
     searched_users = User.simple_search('khan', pattern: :ending, attributes: [:username])
+
     assert_equal ['kingkhan'], searched_users.pluck(:username)
   end
 
   def test_it_searches_the_users_with_email_containing_example_word
+    User.simple_search_attributes :name, :contact, :address
+
     searched_users = User.simple_search('example', pattern: :containing, attributes: [:email])
+
     assert_equal ['alice@example.com', 'bob@example.com'], searched_users.pluck(:email)
   end
 
-  def test_searches_user_with_name_or_address_containing_a_word
+  def test_it_searches_user_with_name_or_address_containing_a_word
+    User.simple_search_attributes :name, :contact, :address
+
     searched_users = User.simple_search('a', pattern: :containing, attributes: [:name, :address])
+
     assert_equal ['alice', 'bob'], searched_users.pluck(:name)
     assert_equal ['usa', 'india'], searched_users.pluck(:address)
+  end
+
+  def test_it_seraches_the_records_from_non_string_and_text_types_data
+    User.simple_search_attributes :age
+
+    user           = User.find_by_age('60')
+    searched_users = User.simple_search('60')
+
+    assert_includes searched_users, user
+
+    User.simple_search_attributes :age, :created_at
+    searched_users = User.simple_search(Date.today.year.to_s)
+
+    assert_equal searched_users.count, User.count
   end
 end
 
 module JoinTest
   def test_simple_search_using_join
+    User.simple_search_attributes :name, :contact, :address
+
     searched_users = User.joins(:posts).simple_search('alice') do |_|
       ['AND posts.name = ? ', 'Ruby is simple' ]
     end


### PR DESCRIPTION
Currently, `simple_search_attributes` method accepts the only **string** and **text** columns but if we want to search through other datatype columns, then currently we need to handle it through the Ruby block (i.e. extending `simple_search` method). I feel that if we pass the integer/decimal/another type attribute to `simple_search_attribute`, it should work fine.